### PR TITLE
Update dependencies. Allow any version of rollup < 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,15 +21,15 @@
   },
   "homepage": "https://github.com/showpad/karma-rollup-preprocessor",
   "dependencies": {
-    "rollup": "^0.26.0"
+    "rollup": "^0.x"
   },
   "devDependencies": {
-    "babel-preset-es2015-rollup": "^1.0.0",
+    "babel-preset-es2015-rollup": "^1.1.1",
     "jasmine-core": "^2.4.1",
-    "karma": "^0.13.15",
-    "karma-jasmine": "^0.3.6",
-    "karma-phantomjs-launcher": "^1.0.0",
+    "karma": "^1.1.1",
+    "karma-jasmine": "^1.0.2",
+    "karma-phantomjs-launcher": "^1.0.1",
     "phantomjs-prebuilt": "^2.1.7",
-    "rollup-plugin-babel": "^2.2.0"
+    "rollup-plugin-babel": "^2.6.1"
   }
 }


### PR DESCRIPTION
As the well functionning of this preprocessor does not really depends of the version of Rollup. I suggest to stick to any version prior to 1.0.0.
All tests are passing.
