### PR TITLE
Add callback to async fs.utimes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,8 +19,9 @@ function createPreprocessor (config, logger) {
 	var recompileDependants = debounce(function () {
 		var now = Date.now();
 		for (var dependant of staleDependants.values()) {
-			fs.utimes(dependant, now, now);
-			log.debug('Recompiling dependant %s', dependant);
+			fs.utimes(dependant, now, now, function() {
+				log.debug('Recompiling dependant %s', dependant);
+			});
 		}
 		staleDependants.clear();
 	}, 50);


### PR DESCRIPTION
Get rid of deprecation warning on Node 7

```
(node:49216) DeprecationWarning: Calling an asynchronous function without callback is deprecated.
    at makeCallback (fs.js:103:12)
    at Object.fs.utimes (fs.js:1127:14)
    at /Users/federicozivolo/Progetti/popper-js/node_modules/karma-rollup-preprocessor/lib/index.js:22:7
    at Timeout.later [as _onTimeout] (/Users/federicozivolo/Progetti/popper-js/node_modules/debounce/index.js:34:23)
    at ontimeout (timers.js:365:14)
    at tryOnTimeout (timers.js:237:5)
    at Timer.listOnTimeout (timers.js:207:5)
```