### PR TITLE
fix: fix rollup 0.45 integration

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,14 +61,15 @@ function createPreprocessor (customConfig, baseConfig, logger) {
 					}
 				}
 
-				const generated = bundle.generate(config)
+				// Return the promise so that errors will be handled by the `catch` statement below.
+				return Promise.resolve(bundle.generate(config)).then((generated) => {
+					const processed = (config.sourceMap === 'inline')
+						? generated.code + `\n//# sourceMappingURL=${generated.map.toUrl()}\n`
+						: generated.code
 
-				const processed = (config.sourceMap === 'inline')
-					? generated.code + `\n//# sourceMappingURL=${generated.map.toUrl()}\n`
-					: generated.code
-
-				cache = bundle
-				done(null, processed)
+					cache = bundle
+					done(null, processed)
+				})
 			})
 			.catch(error => {
 				log.error('Failed to process %s\n\n%s\n', file.originalPath, error.message)


### PR DESCRIPTION
Since version 0.45, the `generate` function of rollup returns a
promise instead of a `{ code, map }` object.
This commit use the native `Promise.resolve` to generate bundle
no matter the result (promise or simple object).

See: https://github.com/rollup/rollup/pull/1475