### PR TITLE
fix: use new rollup `input` option.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,9 @@
 'use strict'
 
 const fs = require('fs')
-const rollup = require('rollup').rollup
+const rollup = require('rollup')
 const _ = require('lodash')
+const semver = require('semver')
 
 
 function createPreprocessor (customConfig, baseConfig, logger) {
@@ -34,10 +35,19 @@ function createPreprocessor (customConfig, baseConfig, logger) {
 		log.debug('Processing %s', file.originalPath)
 
 		try {
-			config.entry = file.originalPath
 			config.cache = cache
 
-			rollup(config).then(bundle => {
+			// The `entry` has been deprecated with rollup 0.48.X, but it has to be
+			// used to support previous version of rollup and other rollup plugins (such
+			// as `rollup-plugin-commonjs`).
+			config.entry = file.originalPath
+
+			// The `input` option has been added with rollup 0.48.X, replacing the `entry` option.
+			if (rollup.VERSION && semver.gte(rollup.VERSION, '0.48.0')) {
+				config.input = file.originalPath
+			}
+
+			rollup.rollup(config).then(bundle => {
 
 				buffer = bundle
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -77,7 +77,8 @@ function createPreprocessor (customConfig, baseConfig, logger) {
 				return bundle.generate(config)
 			})
 			.then(generated => {
-				const processed = (config.sourceMap === 'inline')
+				const sourceMap = config.sourcemap || config.sourceMap
+				const processed = (sourceMap === 'inline')
 					? generated.code + `\n//# sourceMappingURL=${generated.map.toUrl()}\n`
 					: generated.code
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "homepage": "https://github.com/jlmakes/karma-rollup-preprocessor",
   "dependencies": {
     "rollup": ">=0.45.x",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "semver": "^5.4.1"
   },
   "devDependencies": {
     "eslint": "^4.2.0",


### PR DESCRIPTION
Since rollup 0.48, the `entry` option has been renamed
to `input` (see https://github.com/rollup/rollup/commit/31de491896b5e20ef51b19adff0636097c731bb0).

The `entry` is still set for two reasons:
  - Support old versions of rollup (version < 0.48.0).
  - Compatibility with rollup plugins such as `rollup-plugin-commonjs`.

Close #24