### PR TITLE
Fix memory leak caused by caching

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ function createPreprocessor(options, preconfig, basePath, emitter, logger) {
         });
         rollup(config)
             .then(bundle => {
-                cache = bundle;
+                cache = bundle.cache;
                 watch.capture(bundle);
                 return bundle.generate(config);
             })


### PR DESCRIPTION
**Short version:** Even though the documentation says otherwise, using `bundle` as `config.cache` leaks memory and will probably throw an error in the future. Unfortunately, the Rollup documentation does not (yet) reflect this.

**Long version:**
We've migrated a somewhat sizable library to a Rollup build and use this preprocessor for testing. When watching for changes, Node crashes after typically 2-3 file changes. While investigating the problem, I found that not passing a cache fixes the problem (but obviously slows down the build a lot).

I then found [this issue](https://github.com/rollup/rollup/issues/2494), for which a fix was released just days ago. I upgraded to Rollup v0.66.5, but the problem remained. Re-reading the issue, passing a previously generated `bundle` as the `config.cache` option of a subsequent bundle is apparently bad. It may work, but it's not the intended usage and introduces a memory leak. The documentation will hopefully be adapted and passing a bundle may throw in the future. Instead, `bundle.cache` should be passed in `config.cache`. Doing so solves our crashes and works as intended in terms of caching.