### PR TITLE
Fix change watching failure after browser reconnect

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -60,6 +60,7 @@ function Watch(emitter, log) {
 }
 
 Watch.prototype.capture = function(bundle) {
+    this.buffer.clear();
     bundle.modules.forEach(m => this.buffer.add(m.id));
 };
 
@@ -80,7 +81,6 @@ Watch.prototype.start = function() {
             this.watchList.add(m);
         }
     });
-    this.buffer.clear();
 };
 
 createPreprocessor.$inject = [


### PR DESCRIPTION
**Problem**
We've noticed that running an auto-watch Karma task with _karma-rollup-preprocessor_ often becomes stuck after a while. This always happens after Karma indicates that the browser has disconnected, followed by a reconnecting browser. This looks something like this:
```
12:01:49.405:INFO [preprocessor.rollup]: Change detected
12:01:58.283:INFO [preprocessor.rollup]: Generating bundle
12:02:06.775:WARN [HeadlessChrome 0.0.0 (Windows 10 0.0.0)]: Disconnected (1 times)client disconnected from CONNECTED state
HeadlessChrome 0.0.0 (Windows 10 0.0.0) ERROR
  Disconnectedclient disconnected from CONNECTED state
HeadlessChrome 0.0.0 (Windows 10 0.0.0) ERROR
  Disconnectedclient disconnected from CONNECTED state
12:02:07.110:INFO [HeadlessChrome 0.0.0 (Windows 10 0.0.0)]: Connected on socket VMbU1m0Pyz0eVcaXAAAC with id 12144864
```
After this output, the test suite will run but after that, further file changes do no longer trigger regeneration of the bundle (or any other effect). I do  not know the cause of the browser disconnections, but I have not found a way to avoid them and they shouldn't be a problem.

**Solution**
Some debugging has reveiled that a browser reconnection triggers the `run_start` event, and since the buffer of bundled files has already been cleared, all files are unwatched. It's a typical problem when mutating shared state across different methods... See commit message for details.