### PR TITLE
fix: do not watch when karma autoWatch is set to false

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,10 +4,10 @@ const path = require("path");
 const rollup = require("rollup");
 const Watcher = require("./Watcher");
 
-function createPreprocessor(options, preconfig, basePath, emitter, logger) {
+function createPreprocessor(options, preconfig, basePath, emitter, logger, autoWatch) {
   const cache = new Map();
   const log = logger.create("preprocessor.rollup");
-  const watcher = new Watcher(emitter);
+  const watcher = autoWatch ? new Watcher(emitter) : null;
 
   return async function preprocess(original, file, done) {
     const location = path.relative(basePath, file.path);
@@ -20,8 +20,10 @@ function createPreprocessor(options, preconfig, basePath, emitter, logger) {
       const bundle = await rollup.rollup(config);
       cache.set(file.path, bundle.cache);
 
-      const [entry, ...dependencies] = bundle.watchFiles;
-      watcher.add(entry, dependencies);
+      if (watcher) {
+        const [entry, ...dependencies] = bundle.watchFiles;
+        watcher.add(entry, dependencies);
+      }
 
       log.info("Generating bundle for ./%s", location);
       const { output } = await bundle.generate(config);
@@ -55,7 +57,8 @@ createPreprocessor.$inject = [
   "args",
   "config.basePath",
   "emitter",
-  "logger"
+  "logger",
+  "config.autoWatch"
 ];
 
 module.exports = { "preprocessor:rollup": ["factory", createPreprocessor] };


### PR DESCRIPTION
Hi,

When I use the `@next` version of `karma-rollup-preprocessor` (so 7.0.0-rc2 for now), it looks like my unit test suite never ends when `autoWatch` is set to `false`.

I tried to find the reason, and it looks like this is due to this [commit](https://github.com/jlmakes/karma-rollup-preprocessor/commit/3d9058b6878e55babeed769cc037e4fbff5bc6bf). I think the main reason is because files to watch are never removed from the internal map.

This fix may not be the most appropriate, but at least it add a little improvement and do not track files to watch if it is not really needed (so if `autoWatch` is `false`), and fix the issue mentioned above.