### PR TITLE
Pass only `options.output` to `bundle.generate`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ function createPreprocessor(preconfig, config, emitter, logger) {
 			}
 
 			log.info('Generating bundle for ./%s', location)
-			const { output } = await bundle.generate(options)
+			const { output } = await bundle.generate(options.output)
 
 			for (const result of output) {
 				if (!result.isAsset) {


### PR DESCRIPTION
Based on the source of [Rollup](https://github.com/rollup/rollup/blob/master/src/rollup/index.ts#L471-L485), I believe I have found a fix for #59 . I do not know if this should be considered a breaking change or not.