### PR TITLE
Add useful npm keywords for easier discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
 		"export",
 		"plugin",
 		"preprocessor",
+		"karma-preprocessor",
+		"karma-plugin",
+		"karma-rollup",
 		"rollup"
 	],
 	"bugs": {


### PR DESCRIPTION
The [Karma docs on preprocessors](https://karma-runner.github.io/4.0/config/preprocessors.html) allow you to [find preprocessor plugins on npm using the "karma-preprocessor" keyword](https://www.npmjs.com/search?q=keywords%3Akarma-preprocessor). Since this package doesn't have it, I almost missed it and would have gone for an inferior option (less contributors, etc).

Most preprocessors also have `karma-plugin` so I decided to add it for good measure.