### PR TITLE
Fix path generation on non-posix systems

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -80,7 +80,7 @@ function createPreprocessor(preconfig, config, emitter, logger) {
 					 */
 					if (facadeModuleId && !hasNullByte(facadeModuleId)) {
 						let { dir } = path.parse(originalPath)
-						file.path = path.join(dir, fileName)
+						file.path = path.posix.join(dir, fileName)
 					}
 
 					file.sourceMap = map


### PR DESCRIPTION
This is the issue I talked about [here](https://github.com/jlmakes/karma-rollup-preprocessor/issues/65#issuecomment-603305244).

Using `path.join` generates a path that uses platform's separator. But it seems karma uses posix style everywhere, so path should explicitly use posix, otherwise it breaks on Windows.

I do not really know how to make a unit test for this.

For reference, without this fix, 7.0.4 gives this kind of output on Windows:
```
INFO [preprocessor.rollup]: Generating bundle for ./tests\index.js
INFO [karma-server]: Karma v4.4.1 server started at http://localhost:9876/
INFO [launcher]: Launching browsers ChromeHeadless with concurrency unlimited
INFO [launcher]: Starting browser ChromeHeadless
INFO [HeadlessChrome 80.0.3987 (Windows 10.0.0)]: Connected on socket x70xvyh_mjMyqZ1LAAAA with id 31138964
WARN [web-server]: 404: /absoluteD:/projects/skeleton/skeleton-lib/tests/index.js?bee65b484288e8bc11a0b43f3c9778762b209801
WARN [web-server]: 404: /absoluteD:/projects/skeleton/skeleton-lib/tests/index.js?bee65b484288e8bc11a0b43f3c9778762b209801
HeadlessChrome 80.0.3987 (Windows 10.0.0): Executed 0 of 0 SUCCESS (0.002 secs / 0 secs)
```
So no error, but 0 test running ^^