### PR TITLE
Fix stale bundles with shared dependecies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,11 +23,15 @@ function createWatcher(emitter) {
 	}
 
 	const handleChange = path => {
+		// Find all entries which include the changed file as a dependency
+		const pendingFiles = []
 		for (const [entry, dependencies] of files.entries()) {
 			if (entry === path || dependencies.includes(path)) {
-				return refreshFile(entry)
+				pendingFiles.push(entry)
 			}
 		}
+
+		pendingFiles.forEach(file => refreshFile(file))
 	}
 
 	watch.on('change', debounce(handleChange, 150))


### PR DESCRIPTION
When we have two entries `E1` and `E2` and both depend on module `A`, we would previously only update the first entry (`E1`). We never refreshed `E2` making it contain old code.

So we need to collect _all_ entry files which include the changed file somewhere in their dependency tree. Depending on the project this may just be a single entry or multiple ones.

Ran into this issue while converting the test suite over at https://github.com/preactjs/preact away from webpack to rollup.