### PR TITLE
Fix source path in source map

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,6 +61,10 @@ function createPreprocessor(preconfig, config, emitter, logger) {
 				cache: cache.get(originalPath),
 			})
 
+			options.output = Object.assign({}, options.output, {
+				dir: path.dirname(originalPath)
+			})
+
 			let bundle = await rollup.rollup(options)
 			cache.set(originalPath, bundle.cache)
 


### PR DESCRIPTION
Currently the source path in the inline source map is incorrect, due to that it's relative to 'bundle.id'. This PR change it to relative to `originalPath`.

See the example below for before (`test/test/`) vs after (`test/`). This example is produced by introduce some trivial errors in the karma tests in this repository.

Before this PR:

```
FAILED TESTS:
  t1
    Fixture 1
      ✖ should return dependency signature
        Chrome 87.0.4280 (Mac OS X 11.0.0)
      Error: Expected true to be false.
          at <Jasmine>
          at UserContext.<anonymous> (test/test/t1.js:11:20 <- test/t1.js:27:21)
          at <Jasmine>

  t4
    CommonJS Module in typescript
      ✖ Should be defined.
        Chrome 87.0.4280 (Mac OS X 11.0.0)
      Error: Expected false to be true.
          at <Jasmine>
          at UserContext.<anonymous> (test/test/t4.ts:7:21 <- test/t4.js:77:23)
          at <Jasmine>
```

After this PR:

```
FAILED TESTS:
  t1
    Fixture 1
      ✖ should return dependency signature
        Chrome 87.0.4280 (Mac OS X 11.0.0)
      Error: Expected true to be false.
          at <Jasmine>
          at UserContext.<anonymous> (test/t1.js:11:20 <- test/t1.js:27:21)
          at <Jasmine>

  t4
    CommonJS Module in typescript
      ✖ Should be defined.
        Chrome 87.0.4280 (Mac OS X 11.0.0)
      Error: Expected false to be true.
          at <Jasmine>
          at UserContext.<anonymous> (test/t4.ts:7:21 <- test/t4.js:77:23)
          at <Jasmine>
```