### PR TITLE
Set output.dir only if output.file and output.dir are not set

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,9 +61,11 @@ function createPreprocessor(preconfig, config, emitter, logger) {
 				cache: cache.get(originalPath),
 			})
 
-			options.output = Object.assign({}, options.output, {
-				dir: path.dirname(originalPath)
-			})
+			options.output = Object.assign({}, options.output)
+
+			if (options.output.dir === undefined && options.output.file === undefined) {
+				options.output.dir = path.dirname(originalPath)
+			}
 
 			let bundle = await rollup.rollup(options)
 			cache.set(originalPath, bundle.cache)


### PR DESCRIPTION
Fixes #70.