### PR TITLE
log rollup error.message

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -104,7 +104,7 @@ function createPreprocessor(preconfig, config, emitter, logger) {
 			log.warn('Nothing was processed.')
 			done(null, original)
 		} catch (error) {
-			log.error('Failed to process ./%s\n\n%s\n', location, error.stack)
+			log.error('Failed to process ./%s\n%s\n%s\n', location, error.message || "\n", error.stack)
 			done(error, null)
 		}
 	}


### PR DESCRIPTION
Since https://github.com/ezolenko/rollup-plugin-typescript2/pull/373 was implemented the error objects contains message next to stacktrace. The displaying only stacktrace causes that relevant error message of Typescript compiler is lost.